### PR TITLE
openssl: an attempt to fix the database when sharing an SSL session

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -149,6 +149,16 @@ jobs:
               --with-openssl --enable-debug --enable-websockets
             singleuse: --unit
 
+          - name: thread-sanitizer
+            install_packages: zlib1g-dev clang libtsan2
+            install_steps: pytest openssltsan3
+            configure: >
+              CC=clang
+              CFLAGS="-fsanitize=thread -g"
+              LDFLAGS="-fsanitize=thread -Wl,-rpath,$HOME/openssl3/lib"
+              --with-openssl=$HOME/openssl3 --enable-debug --enable-websockets
+            singleuse: --unit
+
           - name: memory-sanitizer
             install_packages: clang
             install_steps:
@@ -308,6 +318,28 @@ jobs:
           git clone --quiet --depth=1 -b ${{ env.openssl3-version }} https://github.com/openssl/openssl
           cd openssl
           ./config --prefix=$HOME/openssl3 --libdir=lib
+          make -j1 install_sw
+
+      - name: cache openssltsan3
+        if: contains(matrix.build.install_steps, 'openssltsan3')
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        id: cache-openssltsan3
+        env:
+          cache-name: cache-openssltsan3
+        with:
+          path: /home/runner/openssl3
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl3-version }}-d8def798
+
+      - name: 'install openssltsan3'
+        if: contains(matrix.build.install_steps, 'openssltsan3') && steps.cache-openssltsan3.outputs.cache-hit != 'true'
+        # There are global data race in openssl:
+        # Cherry-Pick the fix for testing https://github.com/openssl/openssl/pull/24782
+        run: |
+          git clone --quiet --depth=1 -b ${{ env.openssl3-version }} https://github.com/openssl/openssl
+          cd openssl
+          git fetch --quiet --depth=2 origin d8def79838cd0d5e7c21d217aa26edb5229f0ab4
+          git cherry-pick -n d8def79838cd0d5e7c21d217aa26edb5229f0ab4
+          CC="clang" CFLAGS="-fsanitize=thread" LDFLAGS="-fsanitize=thread" ./config --prefix=$HOME/openssl3 --libdir=lib
           make -j1 install_sw
 
       - name: cache quictls

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -134,6 +134,9 @@ jobs:
         timeout-minutes: 10
         run: make -C bld -j5 V=1 -C tests
 
+      - name: 'start trace'
+        if: ${{ matrix.build == 'autotools' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        run: netsh trace start persistent=yes capture=yes tracefile=trace
       - name: 'autotools run tests'
         if: ${{ matrix.build == 'autotools' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 12
@@ -148,7 +151,13 @@ jobs:
           /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 stunnel --force
           PATH="$PATH:/c/Program Files (x86)/stunnel/bin"
           make -C bld -j5 V=1 test-ci
-
+      - name: 'end trace'
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        run: netsh trace stop
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{matrix.name}}.etl
+          path: trace
       - name: 'cmake configure'
         if: ${{ matrix.build == 'cmake' }}
         timeout-minutes: 5
@@ -215,6 +224,10 @@ jobs:
         timeout-minutes: 10
         run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
+      - name: 'start trace'
+        if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        run: netsh trace start persistent=yes capture=yes tracefile=trace
+
       - name: 'cmake run tests'
         if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 12
@@ -230,6 +243,13 @@ jobs:
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
+      - name: 'end trace'
+        if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        run: netsh trace stop
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{matrix.name}}.etl
+          path: trace
   old-mingw-w64:
     name: 'old-mingw, CM ${{ matrix.env }} ${{ matrix.name }}'
     runs-on: windows-latest
@@ -333,6 +353,9 @@ jobs:
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
+      - name: 'start trace'
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        run: netsh trace start persistent=yes capture=yes tracefile=trace
       - name: 'cmake run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 12
@@ -345,7 +368,13 @@ jobs:
           /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 stunnel --force
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
-
+      - name: 'end trace'
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        run: netsh trace stop
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{matrix.name}}.etl
+          path: trace
   linux-cross-mingw-w64:
     name: "linux-mingw, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }}"
     runs-on: ubuntu-latest
@@ -544,6 +573,10 @@ jobs:
         timeout-minutes: 10
         run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
+      - name: 'start trace'
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        run: netsh trace start persistent=yes capture=yes tracefile=trace
+
       - name: 'cmake run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 14
@@ -556,3 +589,10 @@ jobs:
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
+      - name: 'end trace'
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        run: netsh trace stop
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{matrix.name}}.etl
+          path: trace

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -152,9 +152,10 @@ jobs:
           PATH="$PATH:/c/Program Files (x86)/stunnel/bin"
           make -C bld -j5 V=1 test-ci
       - name: 'end trace'
-        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        if: ${{ matrix.build == 'autotools' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         run: netsh trace stop
       - uses: actions/upload-artifact@v4
+        if: ${{ matrix.build == 'autotools' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         with:
           name: ${{matrix.name}}.etl
           path: trace

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -248,6 +248,7 @@ jobs:
         if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         run: netsh trace stop
       - uses: actions/upload-artifact@v4
+        if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         with:
           name: ${{matrix.name}}.etl
           path: trace
@@ -373,6 +374,7 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         run: netsh trace stop
       - uses: actions/upload-artifact@v4
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         with:
           name: ${{matrix.name}}.etl
           path: trace
@@ -594,6 +596,7 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         run: netsh trace stop
       - uses: actions/upload-artifact@v4
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         with:
           name: ${{matrix.name}}.etl
           path: trace

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,6 +5,7 @@
 name: Windows
 
 'on':
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -138,7 +138,7 @@ jobs:
         if: ${{ matrix.build == 'autotools' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 12
         run: |
-          export TFLAGS='-j14 ${{ matrix.tflags }}'
+          export TFLAGS='-j14 -k -v ${{ matrix.tflags }}'
           if [ '${{ matrix.sys }}' != 'msys' ]; then
             TFLAGS+=' ~TFTP ~MQTT ~WebSockets ~SMTP ~FTP'
           fi
@@ -219,7 +219,7 @@ jobs:
         if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 12
         run: |
-          export TFLAGS='-j14 ${{ matrix.tflags }}'
+          export TFLAGS='-j14 -k -v ${{ matrix.tflags }}'
           if [ '${{ matrix.sys }}' != 'msys' ]; then
             TFLAGS+=' ~TFTP ~MQTT ~WebSockets ~SMTP ~FTP'
           fi
@@ -338,7 +338,7 @@ jobs:
         timeout-minutes: 12
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          export TFLAGS='-j14 ~TFTP ~MQTT ~WebSockets ~FTP ${{ matrix.tflags }}'
+          export TFLAGS='-j14 -v -k ~TFTP ~MQTT ~WebSockets ~FTP ${{ matrix.tflags }}'
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -548,7 +548,7 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 14
         run: |
-          export TFLAGS='-j14 ~TFTP ~MQTT ~WebSockets ~SMTP ~FTP ${{ matrix.tflags }}'
+          export TFLAGS='-j14 -k -v ~TFTP ~MQTT ~WebSockets ~SMTP ~FTP ${{ matrix.tflags }}'
           # GnuTLS is not fully functional on Windows, so skip the tests
           # https://github.com/ShiftMediaProject/gnutls/issues/23
           if [ '${{ matrix.name }}' != 'gnutls' ]; then

--- a/lib/curl_memory.h
+++ b/lib/curl_memory.h
@@ -138,7 +138,7 @@ extern curl_calloc_callback Curl_ccalloc;
 extern curl_wcsdup_callback Curl_cwcsdup;
 #endif
 
-#if !defined(CURLDEBUG) && defined(BUILDING_LIBCURL)
+#ifndef CURLDEBUG
 
 /*
  * libcurl's 'memory tracking' system defines strdup, malloc, calloc,

--- a/lib/curl_memory.h
+++ b/lib/curl_memory.h
@@ -138,7 +138,7 @@ extern curl_calloc_callback Curl_ccalloc;
 extern curl_wcsdup_callback Curl_cwcsdup;
 #endif
 
-#ifndef CURLDEBUG
+#if !defined(CURLDEBUG) && defined(BUILDING_LIBCURL)
 
 /*
  * libcurl's 'memory tracking' system defines strdup, malloc, calloc,

--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -35,7 +35,9 @@
 #endif
 
 #include "curl_threads.h"
+#ifdef BUILDING_LIBCURL
 #include "curl_memory.h"
+#endif
 /* The last #include file should be: */
 #include "memdebug.h"
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2010,7 +2010,7 @@ static void ossl_session_free(void *sessionid, size_t idsize)
 {
   /* free the ID */
   (void)idsize;
-  SSL_SESSION_free(sessionid);
+  free(sessionid);
 }
 
 /*
@@ -2875,6 +2875,9 @@ CURLcode Curl_ossl_add_session(struct Curl_cfilter *cf,
 {
   const struct ssl_config_data *config;
   CURLcode result = CURLE_OK;
+  size_t der_session_size;
+  unsigned char *der_session_buf;
+  unsigned char *der_session_ptr;
 
   if(!cf || !data)
     goto out;
@@ -2882,16 +2885,32 @@ CURLcode Curl_ossl_add_session(struct Curl_cfilter *cf,
   config = Curl_ssl_cf_get_config(cf, data);
   if(config->primary.cache_session) {
 
+    der_session_size = i2d_SSL_SESSION(session, NULL);
+    if(der_session_size == 0) {
+      result = CURLE_OUT_OF_MEMORY;
+      goto out;
+    }
+
+    der_session_buf = der_session_ptr = malloc(der_session_size);
+    if(!der_session_buf) {
+      result = CURLE_OUT_OF_MEMORY;
+      goto out;
+    }
+
+    der_session_size = i2d_SSL_SESSION(session, &der_session_ptr);
+    if(der_session_size == 0) {
+      result = CURLE_OUT_OF_MEMORY;
+      free(der_session_buf);
+      goto out;
+    }
+
     Curl_ssl_sessionid_lock(data);
-    result = Curl_ssl_set_sessionid(cf, data, peer, session, 0,
-                                    ossl_session_free);
-    session = NULL; /* call has taken ownership */
+    result = Curl_ssl_set_sessionid(cf, data, peer, der_session_buf,
+     der_session_size, ossl_session_free);
     Curl_ssl_sessionid_unlock(data);
   }
 
 out:
-  if(session)
-    ossl_session_free(session, 0);
   return result;
 }
 
@@ -2908,7 +2927,7 @@ static int ossl_new_session_cb(SSL *ssl, SSL_SESSION *ssl_sessionid)
   connssl = cf? cf->ctx : NULL;
   data = connssl? CF_DATA_CURRENT(cf) : NULL;
   Curl_ossl_add_session(cf, data, &connssl->peer, ssl_sessionid);
-  return 1;
+  return 0;
 }
 
 static CURLcode load_cacert_from_memory(X509_STORE *store,
@@ -3458,7 +3477,9 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
   const char *ciphers;
   SSL_METHOD_QUAL SSL_METHOD *req_method = NULL;
   ctx_option_t ctx_options = 0;
-  void *ssl_sessionid = NULL;
+  SSL_SESSION *ssl_session = NULL;
+  const unsigned char *der_sessionid = NULL;
+  size_t der_sessionid_size = 0;
   struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
   struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
   const long int ssl_version_min = conn_config->version;
@@ -3943,18 +3964,29 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
   octx->reused_session = FALSE;
   if(ssl_config->primary.cache_session && transport == TRNSPRT_TCP) {
     Curl_ssl_sessionid_lock(data);
-    if(!Curl_ssl_getsessionid(cf, data, peer, &ssl_sessionid, NULL)) {
+    if(!Curl_ssl_getsessionid(cf, data, peer, (void **)&der_sessionid,
+      &der_sessionid_size)) {
       /* we got a session id, use it! */
-      if(!SSL_set_session(octx->ssl, ssl_sessionid)) {
-        Curl_ssl_sessionid_unlock(data);
-        failf(data, "SSL: SSL_set_session failed: %s",
-              ossl_strerror(ERR_get_error(), error_buffer,
-                            sizeof(error_buffer)));
-        return CURLE_SSL_CONNECT_ERROR;
+      ssl_session = d2i_SSL_SESSION(NULL, &der_sessionid,
+        (long)der_sessionid_size);
+      if(ssl_session) {
+        if(!SSL_set_session(octx->ssl, ssl_session)) {
+          Curl_ssl_sessionid_unlock(data);
+          SSL_SESSION_free(ssl_session);
+          failf(data, "SSL: SSL_set_session failed: %s",
+                ossl_strerror(ERR_get_error(), error_buffer,
+                              sizeof(error_buffer)));
+          return CURLE_SSL_CONNECT_ERROR;
+        }
+        SSL_SESSION_free(ssl_session);
+        /* Informational message */
+        infof(data, "SSL reusing session ID");
+        octx->reused_session = TRUE;
       }
-      /* Informational message */
-      infof(data, "SSL reusing session ID");
-      octx->reused_session = TRUE;
+      else {
+          Curl_ssl_sessionid_unlock(data);
+          return CURLE_SSL_CONNECT_ERROR;
+      }
     }
     Curl_ssl_sessionid_unlock(data);
   }

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -268,6 +268,6 @@ test3024 test3025 test3026 test3027 test3028 test3029 test3030 \
 \
 test3100 test3101 test3102 test3103 \
 test3200 \
-test3201 test3202 test3203 test3204 test3205
+test3201 test3202 test3203 test3204 test3205 test3207
 
 EXTRA_DIST = $(TESTCASES) DISABLED

--- a/tests/data/test3207
+++ b/tests/data/test3207
@@ -1,0 +1,175 @@
+<testcase>
+<info>
+<keywords>
+HTTPS
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Type: text/html
+Content-Length: 29
+
+run 1: foobar and so on fun!
+</data>
+<datacheck>
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+run 1: foobar and so on fun!
+</datacheck>
+</reply>
+
+# Client-side
+<client>
+<features>
+SSL
+OpenSSL
+</features>
+<server>
+https
+</server>
+<name>
+concurrent HTTPS GET using shared ssl session cache
+</name>
+<tool>
+lib%TESTNUMBER
+</tool>
+# provide URL and ca-cert
+<command>
+https://localhost:%HTTPSPORT/%TESTNUMBER  %SRCDIR/certs/EdelCurlRoot-ca.crt
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+</verify>
+</testcase>

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -207,8 +207,8 @@ sub exit_signal_handler {
     my $signame = shift;
     # For now, simply mimic old behavior.
     killsockfilters($piddir, $proto, $ipvnum, $idnum, $verbose);
-    unlink($pidfile);
-    unlink($portfile);
+    rename($pidfile, $pidfile.".old");
+    rename($portfile, $portfile.".old");
     if($serverlogslocked) {
         $serverlogslocked = 0;
         clear_advisor_read_lock($serverlogs_lockfile);
@@ -382,8 +382,8 @@ sub sysread_or_die {
         logmsg "Exited from sysread_or_die() at $fcaller " .
                "line $lcaller. $srvrname server, sysread error: $!\n";
         killsockfilters($piddir, $proto, $ipvnum, $idnum, $verbose);
-        unlink($pidfile);
-        unlink($portfile);
+        rename($pidfile, $pidfile.".old");
+        rename($portfile, $portfile."old");
         if($serverlogslocked) {
             $serverlogslocked = 0;
             clear_advisor_read_lock($serverlogs_lockfile);
@@ -397,8 +397,8 @@ sub sysread_or_die {
         logmsg "Exited from sysread_or_die() at $fcaller " .
                "line $lcaller. $srvrname server, read zero\n";
         killsockfilters($piddir, $proto, $ipvnum, $idnum, $verbose);
-        unlink($pidfile);
-        unlink($portfile);
+        rename($pidfile, $pidfile.".old");
+        rename($portfile, $portfile."old");
         if($serverlogslocked) {
             $serverlogslocked = 0;
             clear_advisor_read_lock($serverlogs_lockfile);
@@ -427,8 +427,8 @@ sub startsf {
     if($pong !~ /^PONG/) {
         logmsg "Failed sockfilt command: @mainsockfcmd\n";
         killsockfilters($piddir, $proto, $ipvnum, $idnum, $verbose);
-        unlink($pidfile);
-        unlink($portfile);
+        rename($pidfile, $pidfile.".old");
+        rename($portfile, $portfile."old");
         if($serverlogslocked) {
             $serverlogslocked = 0;
             clear_advisor_read_lock($serverlogs_lockfile);
@@ -742,7 +742,7 @@ sub close_dataconn {
                "(pid $datapid)\n";
         print DWRITE "QUIT\n";
         pidwait($datapid, 0);
-        unlink($datasockf_pidfile) if(-f $datasockf_pidfile);
+        rename($datasockf_pidfile, $datasockf_pidfile.".old") if(-f $datasockf_pidfile);
         logmsg "DATA sockfilt for $datasockf_mode data channel quit ".
                "(pid $datapid)\n";
     }
@@ -3361,7 +3361,7 @@ while(1) {
 }
 
 killsockfilters($piddir, $proto, $ipvnum, $idnum, $verbose);
-unlink($pidfile);
+rename($pidfile, $pidfile.".old");
 if($serverlogslocked) {
     $serverlogslocked = 0;
     clear_advisor_read_lock($serverlogs_lockfile);

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -35,7 +35,7 @@ foreach(_target IN LISTS noinst_PROGRAMS)
 
   if(LIB_SELECTED STREQUAL LIB_STATIC)
     # These are part of the libcurl static lib. Do not compile/link them again.
-    list(REMOVE_ITEM _sources ${WARNLESS} ${MULTIBYTE} ${TIMEDIFF})
+    list(REMOVE_ITEM _sources ${WARNLESS} ${MULTIBYTE} ${TIMEDIFF} ${THREADS})
   endif()
 
   string(TOUPPER ${_target} _upper_target)

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -37,6 +37,8 @@ MULTIBYTE = ../../lib/curl_multibyte.c ../../lib/curl_multibyte.h
 TIMEDIFF = ../../lib/timediff.c ../../lib/timediff.h
 SUPPORTFILES = $(TIMEDIFF) first.c test.h
 
+THREADS = ../../lib/curl_threads.c ../../lib/curl_threads.h
+
 # These are all libcurl test programs
 noinst_PROGRAMS = libauthretry libntlmconnect libprereq                  \
  lib500 lib501 lib502 lib503 lib504 lib505 lib506 lib507 lib508 lib509   \
@@ -78,7 +80,7 @@ noinst_PROGRAMS = libauthretry libntlmconnect libprereq                  \
  lib2402 lib2404 lib2405 \
  lib2502 \
  lib3010 lib3025 lib3026 lib3027 \
- lib3100 lib3101 lib3102 lib3103
+ lib3100 lib3101 lib3102 lib3103 lib3207
 
 libntlmconnect_SOURCES = libntlmconnect.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 libntlmconnect_LDADD = $(TESTUTIL_LIBS)
@@ -716,3 +718,6 @@ lib3102_LDADD = $(TESTUTIL_LIBS)
 
 lib3103_SOURCES = lib3103.c $(SUPPORTFILES)
 lib3103_LDADD = $(TESTUTIL_LIBS)
+
+lib3207_SOURCES = lib3207.c $(SUPPORTFILES) $(TESTUTIL) $(THREADS) $(WARNLESS) $(MULTIBYTE)
+lib3207_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib3207.c
+++ b/tests/libtest/lib3207.c
@@ -31,7 +31,7 @@
 #if defined(USE_THREADS_POSIX)
 #include <pthread.h>
 #endif
-#include "../../lib/curl_threads.h"
+#include "curl_threads.h"
 #endif
 
 #define CAINFO libtest_arg2
@@ -91,7 +91,7 @@ test_thread(void *ptr)
   int i;
 
   /* Loop the transfer and cleanup the handle properly every lap. This will
-  //    still reuse X509 cainfo since the pool is in the shared object! */
+    still reuse ssl session since the pool is in the shared object! */
   for(i = 0; i < PER_THREAD_SIZE; i++) {
     CURL *curl = curl_easy_init();
     if(curl) {

--- a/tests/libtest/lib3207.c
+++ b/tests/libtest/lib3207.c
@@ -1,0 +1,231 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "test.h"
+#include "testutil.h"
+#include "memdebug.h"
+
+#include <stdio.h>
+
+#if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)
+#if defined(USE_THREADS_POSIX)
+#include <pthread.h>
+#endif
+#include "../../lib/curl_threads.h"
+#endif
+
+#define CAINFO libtest_arg2
+#define THREAD_SIZE 16
+#define PER_THREAD_SIZE 8
+
+struct Ctx
+{
+  const char *URL;
+  CURLSH *share;
+  int result;
+  int thread_id;
+  struct curl_slist *contents;
+};
+
+static size_t write_memory_callback(void *contents, size_t size,
+  size_t nmemb, void *userp) {
+    /* append the data to contents */
+    size_t realsize = size * nmemb;
+    struct Ctx *mem = (struct Ctx *)userp;
+    char *data = (char *)malloc(realsize + 1);
+    struct curl_slist *item_append = NULL;
+    if(!data) {
+      printf("not enough memory (malloc returned NULL)\n");
+      return 0;
+    }
+    memcpy(data, contents, realsize);
+    data[realsize] = '\0';
+    item_append = curl_slist_append(mem->contents, data);
+    free(data);
+    if(item_append) {
+      mem->contents = item_append;
+    }
+    else {
+      printf("not enough memory (curl_slist_append returned NULL)\n");
+      return 0;
+    }
+    return realsize;
+}
+
+static
+#if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
+DWORD
+#else
+unsigned int
+#endif
+CURL_STDCALL
+#else
+unsigned int
+#endif
+test_thread(void *ptr)
+{
+  struct Ctx *ctx = (struct Ctx *)ptr;
+  CURLcode res = CURLE_OK;
+
+  int i;
+
+  /* Loop the transfer and cleanup the handle properly every lap. This will
+  //    still reuse X509 cainfo since the pool is in the shared object! */
+  for(i = 0; i < PER_THREAD_SIZE; i++) {
+    CURL *curl = curl_easy_init();
+    if(curl) {
+      curl_easy_setopt(curl, CURLOPT_URL, (char *)ctx->URL);
+
+      /* use the share object */
+      curl_easy_setopt(curl, CURLOPT_SHARE, ctx->share);
+      curl_easy_setopt(curl, CURLOPT_CAINFO, CAINFO);
+
+      curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_memory_callback);
+      curl_easy_setopt(curl, CURLOPT_WRITEDATA, ptr);
+      curl_easy_setopt(curl, CURLOPT_VERBOSE, 1);
+
+      /* Perform the request, res will get the return code */
+      res = curl_easy_perform(curl);
+
+      /* always cleanup */
+      curl_easy_cleanup(curl);
+      /* Check for errors */
+      if(res != CURLE_OK) {
+        fprintf(stderr, "curl_easy_perform() failed: %s\n",
+                curl_easy_strerror(res));
+        goto test_cleanup;
+      }
+    }
+  }
+
+test_cleanup:
+  ctx->result = (int)res;
+  return 0;
+}
+
+#if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)
+
+static void my_lock(CURL *handle, curl_lock_data data,
+                    curl_lock_access laccess, void *useptr)
+{
+  curl_mutex_t *mutexes = (curl_mutex_t*) useptr;
+  (void)handle;
+  (void)laccess;
+  Curl_mutex_acquire(&mutexes[data]);
+}
+
+static void my_unlock(CURL *handle, curl_lock_data data, void *useptr)
+{
+  curl_mutex_t *mutexes = (curl_mutex_t*) useptr;
+  (void)handle;
+  Curl_mutex_release(&mutexes[data]);
+}
+
+static void execute(struct Curl_share *share, struct Ctx *ctx)
+{
+  int i;
+  curl_mutex_t mutexes[CURL_LOCK_DATA_LAST - 1];
+  curl_thread_t thread[THREAD_SIZE];
+  for(i = 0; i < CURL_LOCK_DATA_LAST - 1; i++) {
+    Curl_mutex_init(&mutexes[i]);
+  }
+  curl_share_setopt(share, CURLSHOPT_LOCKFUNC, my_lock);
+  curl_share_setopt(share, CURLSHOPT_UNLOCKFUNC, my_unlock);
+  curl_share_setopt(share, CURLSHOPT_USERDATA, (void *)mutexes);
+  curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
+
+  for(i = 0; i < THREAD_SIZE; i++) {
+    thread[i] = Curl_thread_create(test_thread, (void *)&ctx[i]);
+  }
+  for(i = 0; i < THREAD_SIZE; i++) {
+    if(thread[i]) {
+      Curl_thread_join(&thread[i]);
+      Curl_thread_destroy(thread[i]);
+    }
+  }
+  curl_share_setopt(share, CURLSHOPT_LOCKFUNC, NULL);
+  curl_share_setopt(share, CURLSHOPT_UNLOCKFUNC, NULL);
+  for(i = 0; i < CURL_LOCK_DATA_LAST - 1; i++) {
+    Curl_mutex_destroy(&mutexes[i]);
+  }
+}
+
+#else /* without pthread, run serially */
+
+static void execute(struct Curl_share *share, struct Ctx *ctx)
+{
+  int i;
+  (void) share;
+  for(i = 0; i < THREAD_SIZE; i++) {
+    test_thread((void *)&ctx[i]);
+  }
+}
+
+#endif
+
+CURLcode test(char *URL)
+{
+  int res = 0;
+  int i;
+  CURLSH* share;
+  struct Ctx ctx[THREAD_SIZE];
+
+  curl_global_init(CURL_GLOBAL_ALL);
+
+  share = curl_share_init();
+  if(!share) {
+    fprintf(stderr, "curl_share_init() failed\n");
+    goto test_cleanup;
+  }
+
+  for(i = 0; i < THREAD_SIZE; i++) {
+    ctx[i].share = share;
+    ctx[i].URL = URL;
+    ctx[i].thread_id = i;
+    ctx[i].result = 0;
+    ctx[i].contents = NULL;
+  }
+
+  execute(share, ctx);
+
+  for(i = 0; i < THREAD_SIZE; i++) {
+    if(ctx[i].result) {
+      res = ctx[i].result;
+    }
+    else {
+        struct curl_slist *item = ctx[i].contents;
+        while(item) {
+          printf("%s", item->data);
+          item = item->next;
+        }
+    }
+    curl_slist_free_all(ctx[i].contents);
+  }
+
+test_cleanup:
+  if(share)
+    curl_share_cleanup(share);
+  curl_global_cleanup();
+  return (CURLcode)res;
+}

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -252,7 +252,7 @@ sub processexists {
         }
         else {
             # get rid of the certainly invalid pidfile
-            unlink($pidfile) if($pid == pidfromfile($pidfile));
+            rename($pidfile, $pidfile.".old") if($pid == pidfromfile($pidfile));
             # reap its dead children, if not done yet
             pidwait($pid, &WNOHANG);
             # negative return value means dead process
@@ -380,7 +380,7 @@ sub killsockfilters {
             pidkill($pid);
             pidwait($pid, 0);
         }
-        unlink($pidfile) if(-f $pidfile);
+        rename($pidfile, $pidfile.".old") if(-f $pidfile);
     }
 
     return if($proto ne 'ftp');
@@ -394,7 +394,7 @@ sub killsockfilters {
             pidkill($pid);
             pidwait($pid, 0);
         }
-        unlink($pidfile) if(-f $pidfile);
+        rename($pidfile, $pidfile . ".old") if(-f $pidfile);
     }
 }
 
@@ -429,7 +429,7 @@ sub clear_advisor_read_lock {
     my ($filename) = @_;
 
     if(-f $filename) {
-        unlink($filename);
+        rename($filename, $filename . ".old");
     }
 }
 

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -368,8 +368,10 @@ sub cleardir {
             else {
                 # Ignore stunnel since we cannot do anything about its locks
                 my $old_name = "$file" =~ /\.old$/ ? $file : "$file.old"; 
-                if("$file" =~ /^(test|stdout|stderr|trace|curl)/ && !unlink("$dir/$file")) {
-                    $done = 0;
+                if("$file" =~ /^(test|stdout|stderr|trace|curl|([0-9]+))/) {
+                    if(!unlink("$dir/$file")) {
+                        $done = 0;
+                    }
                 } elsif("$file" !~ /_stunnel\.log$/ && !rename("$dir/$file", "$dir/$old_name")) {
                     $done = 0;
                 }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -367,7 +367,10 @@ sub cleardir {
             }
             else {
                 # Ignore stunnel since we cannot do anything about its locks
-                if("$file" !~ /_stunnel\.log$/ && !rename("$dir/$file", "$dir/$file.old")) {
+                my $old_name = "$file" =~ /\.old$/ ? $file : "$file.old"; 
+                if("$file" =~ /^(test|stdout|stderr|trace|curl)/ && !unlink("$dir/$file")) {
+                    $done = 0;
+                } elsif("$file" !~ /_stunnel\.log$/ && !rename("$dir/$file", "$dir/$old_name")) {
                     $done = 0;
                 }
             }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1879,7 +1879,7 @@ sub singletest {
         }
         logmsg $logs;
         updatetesttimings($testnum, %$testtimings);
-        if($error == -2) {
+        if(defined $error && $error == -2) {
             if($postmortem) {
                 # Error indicates an actual problem starting the server, so
                 # display the server logs

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -368,7 +368,7 @@ sub cleardir {
             else {
                 # Ignore stunnel since we cannot do anything about its locks
                 my $old_name = "$file" =~ /\.old$/ ? $file : "$file.old"; 
-                if("$file" =~ /^(test|stdout|stderr|trace|curl|([0-9]+))/) {
+                if("$file" =~ /^(cmd|file|download|test|stdout|stderr|trace|curl|([0-9]+))/) {
                     if(!unlink("$dir/$file")) {
                         $done = 0;
                     }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -367,7 +367,7 @@ sub cleardir {
             }
             else {
                 # Ignore stunnel since we cannot do anything about its locks
-                if(!unlink("$dir/$file") && "$file" !~ /_stunnel\.log$/) {
+                if("$file" !~ /_stunnel\.log$/ && !unlink("$dir/$file")) {
                     $done = 0;
                 }
             }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -367,7 +367,7 @@ sub cleardir {
             }
             else {
                 # Ignore stunnel since we cannot do anything about its locks
-                if("$file" !~ /_stunnel\.log$/ && !unlink("$dir/$file")) {
+                if("$file" !~ /_stunnel\.log$/ && !rename("$dir/$file", "$dir/$file.old")) {
                     $done = 0;
                 }
             }

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2240,7 +2240,7 @@ int main(int argc, char *argv[])
          protocol_type, socket_type, location_str);
 
   /* start accepting connections */
-  rc = listen(sock, 5);
+  rc = listen(sock, 50);
   if(0 != rc) {
     error = SOCKERRNO;
     logmsg("listen() failed with error: (%d) %s", error, sstrerror(error));

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -2994,7 +2994,7 @@ sub stopservers {
             logmsg "$server server unexpectedly alive\n";
             killpid($verb, $pid);
         }
-        rename($pidfile.".old") if(-f $pidfile);
+        rename($pidfile, $pidfile.".old") if(-f $pidfile);
     }
 
     return $result;

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -2340,8 +2340,8 @@ sub displaylogcontent {
 
 sub displaylogs {
 
-    system("netstat -a -o");
-    system("ps -W");
+    print(`netstat -a -o`);
+    print(`ps -W`);
     my $logdir = $LOGDIR;
     opendir(DIR, "$logdir") ||
         die "can't open dir: $!";

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -2339,6 +2339,9 @@ sub displaylogcontent {
 }
 
 sub displaylogs {
+
+    system("netstat -a -o");
+    system("ps -W");
     my $logdir = $LOGDIR;
     opendir(DIR, "$logdir") ||
         die "can't open dir: $!";

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -501,7 +501,7 @@ sub stopserver {
     my $result = 0;
     foreach my $server (@killservers) {
         my $pidfile = $serverpidfile{$server};
-        unlink($pidfile) if(-f $pidfile);
+        rename($pidfile, $pidfile.".old" ) if(-f $pidfile);
     }
 
     return $result;
@@ -1131,7 +1131,7 @@ sub runhttpserver {
     if($pid > 0) {
         stopserver($server, "$pid");
     }
-    unlink($pidfile) if(-f $pidfile);
+    rename($pidfile, $pidfile.".old" ) if(-f $pidfile);
 
     my $srvrname = servername_str($proto, $ipvnum, $idnum);
     my $portfile = $serverportfile{$server};
@@ -1215,7 +1215,7 @@ sub runhttp2server {
     if($pid > 0) {
         stopserver($server, "$pid");
     }
-    unlink($pidfile) if(-f $pidfile);
+    rename($pidfile, $pidfile.".old" ) if(-f $pidfile);
 
     my $srvrname = servername_str($proto, $ipvnum, $idnum);
     my $logfile = server_logfilename($LOGDIR, $proto, $ipvnum, $idnum);
@@ -1276,7 +1276,7 @@ sub runhttp3server {
     if($pid > 0) {
         stopserver($server, "$pid");
     }
-    unlink($pidfile) if(-f $pidfile);
+    rename($pidfile, $pidfile.".old" ) if(-f $pidfile);
 
     my $srvrname = servername_str($proto, $ipvnum, $idnum);
     my $logfile = server_logfilename($LOGDIR, $proto, $ipvnum, $idnum);
@@ -1342,7 +1342,7 @@ sub runhttpsserver {
     if($pid > 0) {
         stopserver($server, "$pid");
     }
-    unlink($pidfile) if(-f $pidfile);
+    rename($pidfile, $pidfile.".old" ) if(-f $pidfile);
 
     my $srvrname = servername_str($proto, $ipvnum, $idnum);
     $certfile = 'stunnel.pem' unless($certfile);
@@ -1420,7 +1420,7 @@ sub runhttptlsserver {
     if($pid > 0) {
         stopserver($server, "$pid");
     }
-    unlink($pidfile) if(-f $pidfile);
+    rename($pidfile, $pidfile.".old" ) if(-f $pidfile);
 
     my $srvrname = servername_str($proto, $ipvnum, $idnum);
     my $logfile = server_logfilename($LOGDIR, $proto, $ipvnum, $idnum);
@@ -1483,7 +1483,7 @@ sub runpingpongserver {
     if($pid > 0) {
         stopserver($server, "$pid");
     }
-    unlink($pidfile) if(-f $pidfile);
+    rename($pidfile, $pidfile.".old" ) if(-f $pidfile);
 
     my $srvrname = servername_str($proto, $ipvnum, $idnum);
     my $logfile = server_logfilename($LOGDIR, $proto, $ipvnum, $idnum);
@@ -1558,7 +1558,7 @@ sub runsecureserver {
     if($pid > 0) {
         stopserver($server, "$pid");
     }
-    unlink($pidfile) if(-f $pidfile);
+    rename($pidfile, $pidfile.".old" ) if(-f $pidfile);
 
     my $srvrname = servername_str($proto, $ipvnum, $idnum);
     $certfile = 'stunnel.pem' unless($certfile);
@@ -1629,7 +1629,7 @@ sub runtftpserver {
     if($pid > 0) {
         stopserver($server, "$pid");
     }
-    unlink($pidfile) if(-f $pidfile);
+    rename($pidfile, $pidfile.".old" ) if(-f $pidfile);
 
     my $srvrname = servername_str($proto, $ipvnum, $idnum);
     my $portfile = $serverportfile{$server};
@@ -1706,7 +1706,7 @@ sub runrtspserver {
     if($pid > 0) {
         stopserver($server, "$pid");
     }
-    unlink($pidfile) if(-f $pidfile);
+    rename($pidfile, $pidfile.".old" ) if(-f $pidfile);
 
     my $srvrname = servername_str($proto, $ipvnum, $idnum);
     my $logfile = server_logfilename($LOGDIR, $proto, $ipvnum, $idnum);
@@ -1786,7 +1786,7 @@ sub runsshserver {
     if($pid > 0) {
         stopserver($server, "$pid");
     }
-    unlink($pidfile) if(-f $pidfile);
+    rename($pidfile, $pidfile.".old" ) if(-f $pidfile);
 
     my $srvrname = servername_str($proto, $ipvnum, $idnum);
     my $logfile = server_logfilename($LOGDIR, $proto, $ipvnum, $idnum);
@@ -1898,7 +1898,7 @@ sub runmqttserver {
     if($pid > 0) {
         stopserver($server, "$pid");
     }
-    unlink($pidfile) if(-f $pidfile);
+    rename($pidfile, $pidfile.".old" ) if(-f $pidfile);
 
     my $srvrname = servername_str($proto, $ipvnum, $idnum);
     my $logfile = server_logfilename($LOGDIR, $proto, $ipvnum, $idnum);
@@ -1954,7 +1954,7 @@ sub runsocksserver {
     if($pid > 0) {
         stopserver($server, "$pid");
     }
-    unlink($pidfile) if(-f $pidfile);
+    rename($pidfile, $pidfile.".old" ) if(-f $pidfile);
 
     my $srvrname = servername_str($proto, $ipvnum, $idnum);
     my $portfile = $serverportfile{$server};
@@ -2026,7 +2026,7 @@ sub rundictserver {
     if($pid > 0) {
         stopserver($server, "$pid");
     }
-    unlink($pidfile) if(-f $pidfile);
+    rename($pidfile, $pidfile.".old" ) if(-f $pidfile);
 
     my $srvrname = servername_str($proto, $ipvnum, $idnum);
     my $logfile = server_logfilename($LOGDIR, $proto, $ipvnum, $idnum);
@@ -2087,7 +2087,7 @@ sub runsmbserver {
     if($pid > 0) {
         stopserver($server, "$pid");
     }
-    unlink($pidfile) if(-f $pidfile);
+    rename($pidfile, $pidfile.".old" ) if(-f $pidfile);
 
     my $srvrname = servername_str($proto, $ipvnum, $idnum);
     my $logfile = server_logfilename($LOGDIR, $proto, $ipvnum, $idnum);
@@ -2148,7 +2148,7 @@ sub runnegtelnetserver {
     if($pid > 0) {
         stopserver($server, "$pid");
     }
-    unlink($pidfile) if(-f $pidfile);
+    rename($pidfile, $pidfile.".old" ) if(-f $pidfile);
 
     my $srvrname = servername_str($proto, $ipvnum, $idnum);
     my $logfile = server_logfilename($LOGDIR, $proto, $ipvnum, $idnum);
@@ -2348,6 +2348,11 @@ sub displaylogs {
     my @logs = readdir(DIR);
     closedir(DIR);
 
+    opendir(DIR, "$logdir/server") ||
+        die "can't open dir: $!";
+    @logs = ((map {"server/$_"} readdir(DIR)), @logs);
+    closedir(DIR);
+
     logmsg "== Contents of files in the $logdir/ dir after server unresponsive\n";
     foreach my $log (sort @logs) {
         if($log =~ /\.(\.|)$/) {
@@ -2380,6 +2385,7 @@ sub displaylogs {
 #          4 for an unsupported server type
 #
 sub startservers {
+
     my @what = @_;
     my ($pid, $pid2);
     my $serr;  # error while starting a server (as of the return enumerations)

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -2575,6 +2575,14 @@ sub startservers {
                     return ("failed stopping unresponsive HTTP server", 3);
                 }
             }
+            if($run{'https'} &&
+               !responsive_http_server("https", $verbose, 0,
+                                       protoport('https'))) {
+                logmsg "* restarting unresponsive HTTPS server\n";
+                if(stopserver('https')) {
+                    return ("failed stopping unresponsive HTTPS server", 3);
+                }
+            }
             if(!$run{'http'}) {
                 ($serr, $pid, $pid2, $PORT{'http'}) =
                     runhttpserver("http", $verbose, 0);

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -2326,8 +2326,9 @@ sub startservers {
            ($what eq "ftp") ||
            ($what eq "imap") ||
            ($what eq "smtp")) {
-            if($torture && $run{$what} &&
+            if($run{$what} &&
                !responsive_pingpong_server($what, "", $verbose)) {
+                logmsg "* restarting unresponsive $what server\n";
                 if(stopserver($what)) {
                     return ("failed stopping unresponsive ".uc($what)." server", 3);
                 }
@@ -2344,6 +2345,7 @@ sub startservers {
         elsif($what eq "ftp-ipv6") {
             if($torture && $run{'ftp-ipv6'} &&
                !responsive_pingpong_server("ftp", "", $verbose, "ipv6")) {
+                logmsg "* restarting unresponsive HTTP server\n";
                 if(stopserver('ftp-ipv6')) {
                     return ("failed stopping unresponsive FTP-IPv6 server", 3);
                 }
@@ -2359,9 +2361,10 @@ sub startservers {
             }
         }
         elsif($what eq "gopher") {
-            if($torture && $run{'gopher'} &&
+            if($run{'gopher'} &&
                !responsive_http_server("gopher", $verbose, 0,
                                        protoport("gopher"))) {
+                logmsg "* restarting unresponsive gopher server\n";
                 if(stopserver('gopher')) {
                     return ("failed stopping unresponsive GOPHER server", 3);
                 }
@@ -2439,9 +2442,10 @@ sub startservers {
             }
         }
         elsif($what eq "http-proxy") {
-            if($torture && $run{'http-proxy'} &&
+            if($run{'http-proxy'} &&
                !responsive_http_server("http", $verbose, "proxy",
                                        protoport("httpproxy"))) {
+                logmsg "* restarting unresponsive HTTP proxy server\n";
                 if(stopserver('http-proxy')) {
                     return ("failed stopping unresponsive HTTP-proxy server", 3);
                 }
@@ -2477,8 +2481,9 @@ sub startservers {
             }
         }
         elsif($what eq "rtsp") {
-            if($torture && $run{'rtsp'} &&
+            if($run{'rtsp'} &&
                !responsive_rtsp_server($verbose)) {
+                logmsg "* restarting unresponsive rtsp server\n";
                 if(stopserver('rtsp')) {
                     return ("failed stopping unresponsive RTSP server", 3);
                 }
@@ -2521,8 +2526,9 @@ sub startservers {
                     return ("failed stopping $what server with different cert", 3);
                 }
             }
-            if($torture && $run{$cproto} &&
+            if($run{$cproto} &&
                !responsive_pingpong_server($cproto, "", $verbose)) {
+                logmsg "* restarting unresponsive $cproto server\n";
                 if(stopserver($cproto)) {
                     return ("failed stopping unresponsive $cproto server", 3);
                 }
@@ -2561,9 +2567,10 @@ sub startservers {
                     return ("failed stopping HTTPS server with different cert", 3);
                 }
             }
-            if($torture && $run{'http'} &&
+            if($run{'http'} &&
                !responsive_http_server("http", $verbose, 0,
                                        protoport('http'))) {
+                logmsg "* restarting unresponsive HTTP server\n";
                 if(stopserver('http')) {
                     return ("failed stopping unresponsive HTTP server", 3);
                 }
@@ -2599,9 +2606,10 @@ sub startservers {
                     return ("failed stopping GOPHERS server with different cert", 3);
                 }
             }
-            if($torture && $run{'gopher'} &&
+            if($run{'gopher'} &&
                !responsive_http_server("gopher", $verbose, 0,
                                        protoport('gopher'))) {
+                logmsg "* restarting unresponsive gopher server\n";
                 if(stopserver('gopher')) {
                     return ("failed stopping unresponsive GOPHER server", 3);
                 }
@@ -2668,8 +2676,9 @@ sub startservers {
                 # for now, we can't run http TLS-EXT tests without gnutls-serv
                 return ("no gnutls-serv (with SRP support)", 4);
             }
-            if($torture && $run{'httptls'} &&
+            if($run{'httptls'} &&
                !responsive_httptls_server($verbose, "IPv4")) {
+                logmsg "* restarting unresponsive httptls server\n";
                 if(stopserver('httptls')) {
                     return ("failed stopping unresponsive HTTPTLS server", 3);
                 }
@@ -2708,8 +2717,9 @@ sub startservers {
             }
         }
         elsif($what eq "tftp") {
-            if($torture && $run{'tftp'} &&
+            if($run{'tftp'} &&
                !responsive_tftp_server("", $verbose)) {
+                logmsg "* restarting unresponsive fftp server\n";
                 if(stopserver('tftp')) {
                     return ("failed stopping unresponsive TFTP server", 3);
                 }

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -2994,7 +2994,7 @@ sub stopservers {
             logmsg "$server server unexpectedly alive\n";
             killpid($verb, $pid);
         }
-        unlink($pidfile) if(-f $pidfile);
+        rename($pidfile.".old") if(-f $pidfile);
     }
 
     return $result;


### PR DESCRIPTION
The SSL_Session object is mutated during connection inside openssl, and it might not be thread-safe. Besides, according to documentation of openssl:

```
SSL_SESSION objects keep internal link information about the session
cache list, when being inserted into one SSL_CTX object's session
cache. One SSL_SESSION object, regardless of its reference count,
must therefore only be used with one SSL_CTX object (and the SSL
objects created from this SSL_CTX object).
```

Instead, serialize the SSL_SESSION before adding it to the cache, and deserialize it after retrieving it from the cache, so that no concurrent write to the same object is infeasible.

Also
 - add a ci test for thread sanitizer
 - add a test for sharing ssl sessions concurrently
 - avoid redefining memory functions when not building libcurl, but including the soruce in libtest
 - increase the conccurent connections limit in sws

Notice that there are fix for a global data race for opennssl which is not yet release. The fix is cherry pick for the ci test with thread sanitizer.
https://github.com/openssl/openssl/commit/d8def79838cd0d5e7c21d217aa26edb5229f0ab4